### PR TITLE
Missing "var" statement in dependencies. (AMD to nodejs)

### DIFF
--- a/source/code/templates/ModuleGeneratorTemplates.coffee
+++ b/source/code/templates/ModuleGeneratorTemplates.coffee
@@ -234,7 +234,7 @@ class ModuleGeneratorTemplates extends Template
     @_genFullBody( # load deps 1st, before kicking off common dynamic code
 
       ( if _.any(@module.nodeDeps,
-          (dep, depIdx)-> (not dep.isSystem) and (@module?.parameters or [])[depIdx]) # has a dep with param
+          (dep, depIdx)=> (not dep.isSystem) and (@module?.parameters or [])[depIdx]) # has a dep with param
           "\nvar "
         else
           ''


### PR DESCRIPTION
uRequire v0.6.10

When convert AMD module to nodejs/commonjs format, the "var" statement is missing at the beginning of dependencies loading.

eg.

AMD source

``` js
define(
  [
    'eagl/core/Pipeline',
    'eagl/lang',
    './Foo'
  ],
  function(
    Pipeline,
    lang,
    Foo
  ){

  //...
  return {};

});
```

"nodejs" result :

``` js
(function (window, global) {

// !! expect "var Pipeline ...."  
  Pipeline = require('../core/Pipeline'),
    lang = require('../lang'),
    Foo = require('./Foo');

module.exports = (function () {
  return {};
}).call(this);


}).call(this, (typeof exports === 'object' ? global : window), (typeof exports === 'object' ? global : window))
```

In [template, l.237](https://github.com/anodynos/uRequire/blob/master/source/code/templates/ModuleGeneratorTemplates.coffee#L237), is the _.any callback should be bound to this?

```
(dep, depIdx)=> (not dep.isSystem) and (@module?.parameters or [])[depIdx]) 
             ^
```

I can submit a PR if you wish.

Pierre
