### PR TITLE
Switch from Gaze to Chokidar.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "escodegen": "1.4.x",
     "esprima": "1.2.x",
     "fsp": "0.1.x",
-    "gaze": "0.5.x",
+    "chokidar": "1.0.x",
     "glob-expand": ">=0.0.2",
     "umatch": "0.2.x",
     "lodash": "2.4.x",

--- a/source/code/process/BundleBuilder.coffee
+++ b/source/code/process/BundleBuilder.coffee
@@ -127,21 +127,17 @@ module.exports = class BundleBuilder
         l.err msg + "it has #{_.size(errors)} - Watching again..."
 
     watchFiles = []
-    gaze = require 'gaze'
+    chokidar = require 'chokidar'
     path = require 'path'
     fs = require 'fs'
 
-    gaze bundleBuilder.bundle.path + '/**/*', (err, watcher)->
-      watcher.on 'all', (event, filepath)->
-        if event isnt 'deleted'
-          try
-            filepathStat = fs.statSync filepath # i.e '/mnt/dir/mybundle/myfile.js'
-          catch err
-
+    chokidar.watch(bundleBuilder.bundle.path + '/**/*', alwaysStat: true)
+      .on 'all', (event, filepath, filepathStat) ->
         filepath = path.relative process.cwd(), filepath # i.e 'mybundle/myfile.js'
 
         if filepathStat?.isDirectory()
-          l.warn "Adding '#{filepath}' as new watch directory is NOT SUPPORTED by gaze."
+          # ? It is supported.
+          l.warn "Adding '#{filepath}' as new watch directory is NOT SUPPORTED."
         else
           l.verbose "Watched file '#{filepath}' has '#{event}'. \u001b[33m (waiting watch events for #{options.debounceDelay}ms)"
           watchFiles.push path.relative bundleBuilder.bundle.path, filepath


### PR DESCRIPTION
Hey there.

This commits switches `gaze` to a better file watcher, chokidar.

To summarize: chokidar is *very* stable, and is much faster on OSX, with less CPU usage because of `fsevents`.

Chokidar has been downloaded over 1.2M times last month and is used by very popular projects.