### PR TITLE
feature: `dependencies.imports` and `module.injectDeps()` now inject …

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -50,7 +50,7 @@ module.exports = gruntFunction = (grunt) ->
   splitTasks = (tasks)-> if (tasks instanceof Array) then tasks else tasks.split(/\s/).filter((f)->!!f)
   grunt.registerTask shortCut, "urequire:#{shortCut}" for shortCut of gruntConfig.urequire
   grunt.registerTask shortCut, splitTasks tasks for shortCut, tasks of {
-    default: 'clean lib spec'
+    default: 'clean lib spec copy'
     develop: 'clean lib specWatch'
   }
   require('load-grunt-tasks')(grunt)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "urequire",
   "description": "Convert AMD & commonjs modules to UMD, AMD, commonjs or `combined.js` (rjs & almond) & run/test on nodejs, Web/AMD or Web/Script. Manipulate & inject module code & dependencies while building & more",
-  "version": "0.7.0-beta.30",
+  "version": "0.7.0-beta.31",
   "homepage": "http://uRequire.org",
   "author": {
     "name": "Agelos Pikoulas",

--- a/source/code/config/MasterDefaultsConfig.coffee.md
+++ b/source/code/config/MasterDefaultsConfig.coffee.md
@@ -160,35 +160,42 @@ All information related to dependencies handling is listed here.
 
 #### bundle.dependencies.imports
 
-Allows you to *export* or [*inject*](resourceconverters.coffee#inject-replace-dependencies) (i.e have available) specific dependencies (other modules) throughout the *whole bundle*, under the given variable name(s).
+Allows you to *import* or better *inject* via [`Module.injectdeps()`](resourceconverters.coffee#injectdeps) specific dependencies (i.e other modules) throughout the *whole bundle*, under the given variable name(s).
 
-Eg you want to access `'underscore'` from  `_`, `'backbone'` from `Backbone` etc, from all modules, without having to declare it in each module.
+The use case is when you want to access `lodash` from  as `_`, `backbone` as `Backbone` and even `myUtils/foobar` as `foobar` in all your other modules, without having to declare a boring `var _ = require('lodash')` in each and every module.
 
-Effectively this means that each module will have an *injection* of all `dependencies.imports`, so you don't have to list them in each module.
+Each module receives an *injection* of all the `dependencies.imports`, so you don't have to list them in each module.
 
 @example
 
 ```
-{ 'underscore': '_',
- 'jquery': ["$", "jQuery"],
- 'models/PersonModel': ['persons', 'personsModel'] }
+dependencies: { 
+  imports: { 
+   'lodash': '_',
+   'jquery': ["$", "jQuery"],
+   'myUtils/foobar': ['foobar', 'utilsFoobar'], 
+   'common/config': 'config'
+}}
 ```
 
 will give you :
 
-* Injection of Modules / dependencies `'underscore'`, `'jquery'`, and `'models/PersonModel'` to each module in the bundle.
+* Injection of Modules / dependencies `'lodash'`, `'jquery'`, `'myUtils/foobar'` and `'common/config'` to each module in the bundle, BUT avoiding circular references, so your *bundle's modules* listed in `dependencies.imports` (like `'myUtils/foobar'` and `'common/config'`) will not be injected in each other at all, but will receive all the local deps like `'lodash'`. See more details on this and how injection works in [`Module.injectdeps()`](resourceconverters.coffee#injectdeps).    
 
-* Access of `_`, `$`, `jQuery`, `persons` & `personsModel` variables everywhere, without listing them once on any module's code.
+* Accessing of `_`, `$`, `jQuery` and `'foobar'` and `'common'` variables everywhere.
 
 * Working the same way on all templates, on any environment (AMD, nodejs, Web/Script).
 
-* Saving space: on ['combined' template](combined-template), they are listed & loaded only once, made available only within bundle's 'combined' closure.
+* Saving space: on ['combined' template](combined-template), all `dependencies.imports` are required (& loaded) only once, made available from within the bundle's 'combined' closure.
 
 @type [depsVars](types-and-derive#depsVars)
 
 @derive [dependenciesbindings](types-and-derive#dependenciesbindings)
 
 @note the [shortcut depsvars format](Types-and-derive#shortcut-depsvars-types), can also be used (eg `['underscore', 'jquery', 'models/PersonModel']`), in which case the [vars are inferred]](types-and-derive#inferred-binding-idenifiers).
+
+@see [`Module.injectdeps()`](resourceconverters.coffee#injectdeps) which powers `dependencies.imports` - use it to customize even more the dependency injection behavior.      
+
 
 @alias `bundleExports`, `exports.bundle` both DEPRECATED
 

--- a/source/code/config/ResourceConverters.coffee.md
+++ b/source/code/config/ResourceConverters.coffee.md
@@ -670,16 +670,17 @@ The deps are are always given in [bundleRelative](Flexible-Path-Conventions#bund
 
 Dependencies are also NOT injected in these two cases that would create Circular dependencies: 
 
-* In all other injected dependencies of `depVars` in this `modyle.injectDeps(depVars)` call. This makes sure that in
+* In other injected bundle dependencies of `depVars` in this `modyle.injectDeps(depVars)` call. This makes sure that in
 ```
   modyle.injectDeps({
+    'lodash': '_',
     'utils/MyError': 'MyError',
     'utils/functionalUtils': 'functionalUtils'
   });
 ```
-both `utils/MyError` & `utils/functionalUtils` will NOT be injected in each other. 
+both `utils/MyError` & `utils/functionalUtils` will NOT be injected in each other, BUT `'lodash'` will be (cause its a `local` and not part of your bundles modules) . 
 
-* when the module A that is the dependency to be injected in module B, already a dependency to B. So consider a call to 
+* when the module A that is the dependency to be injected in module B, is already a dependency to B. So consider a call to 
  
 ``` 
   modyle.injectDeps({'config': 'config' });
@@ -690,7 +691,7 @@ where `config.js` module is
    
   module.exports = helpers.deepMerge(defaultConfig, {foo: {bar: ''}});
 ```
-and we are about to inject `config.js` as a dependency into `common/defaultConfig`. In this case, we would create a circular dependency which is not what we intended, so urequire will make the decision NOT to inject.
+and we are about to inject `config.js` as a dependency into `common/defaultConfig`. In this case, if we injected we would have created a circular dependency which is not what we intended, so urequire will make the decision NOT to inject.
                 
 In these two case, you have to do it explicitly `var a = require('some/other/injected/mod')` and know what you're doing. Also you can `modyle.injectDeps({'config': 'config' }, true);` to force circular deps to be injected.
  

--- a/source/code/fileResources/Dependency.coffee
+++ b/source/code/fileResources/Dependency.coffee
@@ -143,11 +143,11 @@ class Dependency
       deps = @module.bundle.dependencies
       pkg = @module.bundle.package
       depPlaces = [
-        deps.locals
+        deps?.locals
         MasterDefaultsConfig.bundle.dependencies.locals
-        deps.paths.bower
-        pkg.dependencies
-        pkg.devDependencies
+        deps?.paths.bower
+        pkg?.dependencies
+        pkg?.devDependencies
       ]
       for depPlace in depPlaces when depPlace
         return true if depPlace[firstPart]
@@ -357,7 +357,7 @@ class Dependency
         newDepString = newDep.pluginName + '!' + newDepString
 
     l.deb """Dependency.update replacing @depString '#{@depString}' with '#{newDepString}'.""" if l.deb(90)
-    @depString = newDepString # also sets ASTs    
+    @depString = newDepString # also sets ASTs
 
 module.exports = Dependency
 


### PR DESCRIPTION
…non-bundle deps (eg 'lodash') even on other injected modules. Only bundle dependencies are prevented from being injected.